### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/action-version-updater.yml
+++ b/.github/workflows/action-version-updater.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.1
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}
 
       - name: Run GitHub Actions Version Updater
-        uses: saadmk11/github-actions-version-updater@v0.7.4
+        uses: saadmk11/github-actions-version-updater@v0.8.1
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}

--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Backend
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Setup Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3.0.0
 
       - name: Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.2
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -27,13 +27,13 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Docker Hub login
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3.0.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: GitHub container Registry login
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3.0.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -45,7 +45,7 @@ jobs:
 
       - name: Build and Push Arm
         id: docker_build_arm
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5.0.0
         with:
           context: ./
           file: ./DockerfileM1
@@ -63,7 +63,7 @@ jobs:
 
       - name: Build and Push
         id: docker_build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5.0.0
         with:
           context: ./
           file: ./Dockerfile


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v3.3.2](https://github.com/actions/cache/releases/tag/v3.3.2)** on 2023-09-07T20:33:08Z
* **[docker/login-action](https://github.com/docker/login-action)** published a new release **[v3.0.0](https://github.com/docker/login-action/releases/tag/v3.0.0)** on 2023-09-12T07:51:46Z
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v3.0.0](https://github.com/docker/setup-buildx-action/releases/tag/v3.0.0)** on 2023-09-12T08:03:47Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.1](https://github.com/actions/checkout/releases/tag/v4.1.1)** on 2023-10-17T15:53:17Z
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v5.0.0](https://github.com/docker/build-push-action/releases/tag/v5.0.0)** on 2023-09-12T07:46:14Z
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.8.1](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.8.1)** on 2023-08-13T13:53:59Z
