### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -19,7 +19,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.0.0
 
       - name: Cache Docker layers
-        uses: actions/cache@v3.3.2
+        uses: actions/cache@v3.3.3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -45,7 +45,7 @@ jobs:
 
       - name: Build and Push Arm
         id: docker_build_arm
-        uses: docker/build-push-action@v5.0.0
+        uses: docker/build-push-action@v5.1.0
         with:
           context: ./
           file: ./DockerfileM1
@@ -63,7 +63,7 @@ jobs:
 
       - name: Build and Push
         id: docker_build
-        uses: docker/build-push-action@v5.0.0
+        uses: docker/build-push-action@v5.1.0
         with:
           context: ./
           file: ./Dockerfile


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v5.1.0](https://github.com/docker/build-push-action/releases/tag/v5.1.0)** on 2023-11-17T12:46:31Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v3.3.3](https://github.com/actions/cache/releases/tag/v3.3.3)** on 2024-01-11T16:38:48Z
